### PR TITLE
Fix xmls that are not valid as Oozie workflow

### DIFF
--- a/chapter-04/email-wf/src/main/xml/workflow.xml
+++ b/chapter-04/email-wf/src/main/xml/workflow.xml
@@ -28,8 +28,8 @@
 
   <start to="myEmailAction"/>
 
-  <action name=" myEmailAction ">
-    <email>
+  <action name="myEmailAction">
+    <email xmlns="uri:oozie:email-action:0.2">
       <to>joe@initech.com,the_other_joe@initech.com</to>
       <cc>john@initech.com</cc>
       <subject>Email notifications for ${wf:id()}</subject>

--- a/chapter-04/fs-wf/src/main/xml/workflow.xml
+++ b/chapter-04/fs-wf/src/main/xml/workflow.xml
@@ -33,7 +33,7 @@
       <name-node>hdfs://nn.mycompany.com:8020</name-node>
       <delete path='/hdfs/user/joe/logs'/>
       <mkdir path='/hdfs/user/joe/logs'/>
-      <chmod path='/hdfs/user/joe/' permissions='755' dir-files='true'>
+      <chmod path='/hdfs/user/joe/' permissions='755' dir-files='true'/>
     </fs>
     <ok to="success"/>
     <error to="fail"/>

--- a/chapter-04/hive-wf/src/main/xml/workflow.xml
+++ b/chapter-04/hive-wf/src/main/xml/workflow.xml
@@ -29,7 +29,7 @@
   <start to="myHiveAction"/>
 
   <action name="myHiveAction">
-    <hive>
+    <hive xmlns="uri:oozie:hive-action:0.6">
       <job-tracker>jt.mycompany.com:8032</job-tracker>
       <name-node>hdfs://nn.mycompany.com:8020</name-node>
       <job-xml>hive-config.xml</job-xml>

--- a/chapter-04/shell-wf/src/main/xml/workflow.xml
+++ b/chapter-04/shell-wf/src/main/xml/workflow.xml
@@ -34,7 +34,7 @@
       <name-node>hdfs://nn.mycompany.com:8020</name-node>
       <exec>/usr/bin/python</exec>
       <argument>test.py</argument>
-      <argument>07/21/2014/argument>
+      <argument>07/21/2014</argument>
       <env-var>TZ=PST</env-var>
       <file>test.py#test.py</file>
       <capture-output/>

--- a/chapter-04/sqoop-wf/src/main/xml/workflow.xml
+++ b/chapter-04/sqoop-wf/src/main/xml/workflow.xml
@@ -30,8 +30,8 @@
 
   <action name="sqoop-import">
     <sqoop xmlns="uri:oozie:sqoop-action:0.2">
-      <job-tracker>jt.mycompany.com:8032$lt;/job-tracker>
-      <name-node>hdfs://nn.mycompany.com:8020$lt;/name-node>
+      <job-tracker>jt.mycompany.com:8032</job-tracker>
+      <name-node>hdfs://nn.mycompany.com:8020</name-node>
       <prepare>
         <delete path=" hdfs://nn.mycompany.com:8020/hdfs/joe/sqoop/output-data"/>
       </prepare>

--- a/chapter-04/ssh-wf/src/main/xml/workflow.xml
+++ b/chapter-04/ssh-wf/src/main/xml/workflow.xml
@@ -28,9 +28,9 @@
 
   <start to="mySSHAction"/>
 
-  <action name=" mySSHAction ">
-    <ssh>
-      <host>foo@bar.com<host>
+  <action name="mySSHAction">
+    <ssh xmlns="uri:oozie:ssh-action:0.2">
+      <host>foo@bar.com</host>
       <command>uploaddata</command>
       <args>jdbc:derby://bar.com:1527/myDB</args>
       <args>hdfs://foobar.com:8020/usr/joe/myData</args>


### PR DESCRIPTION
The examples for chapter 4 appears to contain some invalid xmls, so fixed them.

```
$ for i in $(find . -name workflow.xml); do if ! oozie validate $i >/dev/null 2>&1; then echo $i; fi; done
./chapter-04/email-wf/src/main/xml/workflow.xml
./chapter-04/ssh-wf/src/main/xml/workflow.xml
./chapter-04/hive-wf/src/main/xml/workflow.xml
./chapter-04/sqoop-wf/src/main/xml/workflow.xml
./chapter-04/shell-wf/src/main/xml/workflow.xml
./chapter-04/fs-wf/src/main/xml/workflow.xml
```
